### PR TITLE
Update validate_email.py

### DIFF
--- a/validate_email.py
+++ b/validate_email.py
@@ -5,6 +5,7 @@ import smtplib
 from smtplib import SMTPServerDisconnected
 import logging
 import threading
+import csv
 class emailFilter(threading.Thread):
 
 
@@ -79,8 +80,7 @@ def filterMails(rows,fname,chunk=50):
                        logging.exception("failed to start thread id %d"%(i))
         print("Total %d threads are running"%len(threads))
 
-
-
+        
         for t in threads:
             t.join()
             rejected+=t.getRejected()
@@ -88,5 +88,19 @@ def filterMails(rows,fname,chunk=50):
         print("Total Rejected: %s Total Accepted: %s"%(len(rejected),len(accepted)))
         open('rejected_from_%s.txt'%fname,'w').write(','.join(rejected))
 
-                
-                        
+        #This will help us to judge about the accuracy of emails in a better way
+
+        with open('email%s.csv'%fname,'w') as f:
+                fieldnames=['Accepted_mails','Rejected_mails']
+                writer = csv.DictWriter(f,fieldnames=fieldnames,dialect=csv.excel)
+
+                writer.writeheader()
+
+                for accept in accepted:
+                    writer.writerow({fieldnames[0]:accept})
+                for reject in rejected:
+                    writer.writerow({fieldnames[1]:reject})
+                ##later on we can specially look into those email ids which did not responded
+
+                f.close()
+                #print "Done"


### PR DESCRIPTION
All emails are classified here into 2 categories
1. Accpeted_Mails
2. Rejected_Mails

But there is a third category also where mail ids are not responding.
Those email id's have been added to Accepted_Mails for now.
Unfortunately some of these emails in this 3rd category bounces back
eg: in the file thrissur_output_1.csv mail id's like 
kl.kunnamkulam@caddcentre.ws
rosario@focuzinfotech.com

Email to these accounts included in the Accepted_Email section have bounced back.
Apart from these emails, rest all emails hopefully work, based in the observations of a small sample set.
